### PR TITLE
Add --seed argument for providing a randomness seed

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -56,6 +56,8 @@ else:
 if args.seed is None:
     timestamp = time.time_ns().to_bytes(16, byteorder='big')
     SEED = b64encode(timestamp).decode("utf-8") # Encode timestamp to a base64 string
+else:
+    SEED = args.seed[0]
 print(f"Using randomness seed: {SEED}")
 
 ## Generate Traits


### PR DESCRIPTION
Added an optional argument `--seed` to `generate.py` to provide the global randomness seed `SEED`.
If none is provided, the system timestamp is used as a seed and printed in console.

Multiple runs of `generate.py` should result in the same images being generated.

Each image gets its own `image_seed` based on the global seed and the image ID.